### PR TITLE
Prevent potential memleak

### DIFF
--- a/packages/stencil-store/package-lock.json
+++ b/packages/stencil-store/package-lock.json
@@ -6042,8 +6042,7 @@
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
     "pretty-format": {
       "version": "24.9.0",

--- a/packages/stencil-store/src/subscriptions/stencil.ts
+++ b/packages/stencil-store/src/subscriptions/stencil.ts
@@ -2,7 +2,27 @@
 import { forceUpdate, getRenderingElement } from '@stencil/core';
 
 import { ObservableMap } from '../types';
-import { appendToMap } from '../utils';
+import { appendToMap, debounce } from '../utils';
+
+/**
+ * Check if a possible element isConnected.
+ * The property might not be there, so we check for it.
+ *
+ * We want it to return true if isConnected is not a property,
+ * otherwise we would remove these elements and would not update.
+ *
+ * Better leak in Edge than to be useless.
+ */
+const isConnected = (maybeElement: any) =>
+  !('isConnected' in maybeElement) || maybeElement.isConnected;
+
+const cleanupElements = debounce(async (map: Map<string, any[]>) => {
+  const keys = Array.from(map.keys());
+
+  for (let key of keys) {
+    map.set(key, map.get(key).filter(isConnected));
+  }
+}, 2_000);
 
 export const stencilSubscription = <T>({ subscribe }: Pick<ObservableMap<T>, 'subscribe'>) => {
   const elmsToUpdate = new Map<string, any[]>();
@@ -30,4 +50,5 @@ export const stencilSubscription = <T>({ subscribe }: Pick<ObservableMap<T>, 'su
       }
     },
   });
+  subscribe(() => cleanupElements(elmsToUpdate));
 };

--- a/packages/stencil-store/src/utils.ts
+++ b/packages/stencil-store/src/utils.ts
@@ -37,3 +37,21 @@ export const toSubscription = <T>(
     }
   };
 };
+
+export const debounce = <T extends (...args: any) => any>(
+  fn: T,
+  ms: number
+): ((...args: Parameters<T>) => void) => {
+  let timeoutId;
+  return (...args: Parameters<T>) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = setTimeout(() => {
+      timeoutId = null;
+      fn.apply(args);
+    }, ms);
+  };
+};
+
+export const forMs = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
Pros:

1. It cleans up the elemsToUpdate map.
2. Debounces the call 2 seconds (I rather not use requestIdleCallback or
   have to polyfill it).

Cons:

1. It does not use `requestIdleCallback` which is not fully supported yet.
2. It does not batch removals if there are too many elements to update
   (not sure this is a problem).
3. Relays on `isConnected`, which is not supported in Edge (until it is
   based in Blink, which should be around the corner).

Fixes #1